### PR TITLE
Speed up build by not building examples and tests

### DIFF
--- a/script/buildAddon.sh
+++ b/script/buildAddon.sh
@@ -5,6 +5,7 @@ commit=55668e9003dfb148bc74b9c5d4a41facc5bad5c7
 rDIR=$(pwd)
 rnd=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 13 ; echo)
 tmpDir=/tmp/$rnd
+makeTarget=build
 
 mkdir -p $tmpDir
 
@@ -18,9 +19,9 @@ git checkout $commit
 
 
 if [ "$(uname)" == "Darwin" ]; then
-	make CFLAGS='-mmacosx-version-min=10.7' PG_CFLAGS='-mmacosx-version-min=10.7'
+	make CFLAGS='-mmacosx-version-min=10.7' PG_CFLAGS='-mmacosx-version-min=10.7' $makeTarget
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	make CFLAGS='' PG_CFLAGS=''
+	make CFLAGS='' PG_CFLAGS='' $makeTarget
 fi
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Building the default target which includes examples and tests:
```
$ time make
[...]
make  55.96s user 6.75s system 91% cpu 1:08.67 total
```

Only using the build target:
```
$ time make build
[...]
make build  37.11s user 2.96s system 98% cpu 40.699 total
```